### PR TITLE
Add Twilio API to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,3 +39,4 @@ typed-ast==1.4.0
 urllib3==1.25.3
 Werkzeug==0.15.4
 wrapt==1.11.2
+twilio~=6.0.0


### PR DESCRIPTION
# Summary
Append twilio~=6.0.0 to requirements.txt

## Test Plan

- [x] `pip install -r requirements.txt` prompts `Collecting twilio~=6.0.0`
- [x] `pip list` includes `twilio 6.0.0` after `pip install`

## Related Issues
#1 
