### PR TITLE
Verify types

### DIFF
--- a/backend/app/main/answer_views.py
+++ b/backend/app/main/answer_views.py
@@ -3,22 +3,41 @@ from twilio.twiml.messaging_response import MessagingResponse
 
 from . import main
 from .. import db
-from .models import Answer, Question
+from .models import Answer, Question, TYPE_OBJECTS
 
 
 @main.route('/answer/<question_id>', methods=['POST'])
 def answer(question_id):
     question = Question.query.get(question_id)
 
+    # Verify the response matches the expected type
+    # If not, prompt user
+    if not is_allowed_answer(request.values['Body'], question.kind):
+        return redirect_invalid_twiml(question)
+	
     db.save(Answer(content=request.values['Body'],
-                   question=question,
-                   session_id=session['id']))
+            question=question,
+            session_id=session['id']))
 
     next_question = question.next()
     if next_question:
         return redirect_twiml(next_question)
     else:
         return goodbye_twiml()
+
+
+# Verify that the answer matches the expected type
+def is_allowed_answer(body, kind):
+    return TYPE_OBJECTS[kind].is_of_type(body)
+
+
+# Redirect invalid answer
+def redirect_invalid_twiml(question):
+    response = MessagingResponse()
+    response.message("Invalid response. Please try again!")
+    response.redirect(url=url_for('main.question', question_id=question.id),
+                      method='GET')
+    return str(response)
 
 
 # Redirect to the question route

--- a/backend/app/main/models.py
+++ b/backend/app/main/models.py
@@ -1,6 +1,8 @@
 import json
 from app import db
+from abc import ABC, abstractmethod
 from werkzeug.security import generate_password_hash, check_password_hash
+import re
 
 # create model classes here
 
@@ -23,12 +25,12 @@ class Question(db.Model):
     __tablename__ = 'questions'
 
     TEXT = 'text'
-    NUMERIC = 'numeric'
-    BOOLEAN = 'boolean'
+    EMAIL = 'email'
+    ENUM = 'enum'
 
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.String, nullable=False)
-    kind = db.Column(db.Enum(TEXT, NUMERIC, BOOLEAN, name='question_kind'))
+    kind = db.Column(db.Enum(TEXT, EMAIL, ENUM, name='question_kind'))
     survey_id = db.Column(db.Integer, db.ForeignKey('surveys.id'))
     answers = db.relationship('Answer', backref='question', lazy='dynamic')
 
@@ -62,3 +64,47 @@ class Answer(db.Model):
         self.content = content
         self.question = question
         self.session_id = session_id
+
+
+class ResponseType(ABC):    
+
+    @abstractmethod
+    def is_of_type(self, arg):
+        pass
+    
+    @abstractmethod
+    def instruction_text(self):
+        pass
+
+
+class TextResponse(ResponseType):
+    def is_of_type(self, arg):
+        return True
+
+    def instruction_text(self):
+        return 'Please type your answer.'
+
+
+class EmailResponse(ResponseType):
+    def is_of_type(self, arg):
+        return re.match(r'[^@]+@[^@]+\.[^@]+', arg)
+
+    def instruction_text(self):
+        return 'Please type your answer.'
+
+
+class EnumResponse(ResponseType):
+    def is_of_type(self, arg):
+        return True
+
+    def instruction_text(self):
+        return 'Please enter the corresponding number or text for "Other" or "Prefer not to say".'
+
+
+# Connect db types with their corresponding objects
+# for SMS instructions and validating responses
+TYPE_OBJECTS = {
+    Question.TEXT: TextResponse(),
+    Question.EMAIL: EmailResponse(),
+    Question.ENUM: EnumResponse()
+}

--- a/backend/app/main/models.py
+++ b/backend/app/main/models.py
@@ -101,23 +101,20 @@ class EmailResponse(ResponseType):
 class EnumResponse(ResponseType):
     def __init__(self, question=None):
         self.question = question
-    
+
     def is_of_type(self, arg):
         try:
             if self.map_value(arg) is not None:
                 return True
             else:
                 return False
-        except TypeError:
-            return False
-        except IndexError:
+        except (TypeError, IndexError):
             return False
 
     def instruction_text(self):
         return 'Please enter the corresponding number.'
 
     def map_value(self, body):
-        print(self.question.get_enum_values())
         return (self.question.get_enum_values())[int (body)]
 
 # Connect db types with their corresponding objects

--- a/backend/app/main/question_views.py
+++ b/backend/app/main/question_views.py
@@ -2,7 +2,7 @@ from flask import session
 from twilio.twiml.messaging_response import MessagingResponse
 
 from . import main
-from .models import Question
+from .models import Question, TYPE_OBJECTS
 
 # Get the next question
 @main.route('/question/<question_id>', methods=['GET'])
@@ -17,15 +17,5 @@ def question(question_id):
 def sms_twiml(question):
     response = MessagingResponse()
     response.message(question.content)
-    response.message(SMS_INSTRUCTIONS[question.kind])
+    response.message(TYPE_OBJECTS[question.kind].instruction_text())
     return str(response)
-
-
-# Sample instruction texts for different types of questions
-# TODO add any missing ones
-# TODO verify that answers conform to the question type
-SMS_INSTRUCTIONS = {
-    Question.TEXT: 'Please type your answer',
-    Question.BOOLEAN: 'Please type 1 for yes and 0 for no',
-    Question.NUMERIC: 'Please type a number between 1 and 10'
-}

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -15,6 +15,8 @@ def sms_signup():
     if survey_error(signup_survey, response.message):
         return str(response)
     
+    session['id'] = request.values['Body']
+
     if 'question_id' in session:
         response.redirect(url_for('main.answer',
                                   question_id=session['question_id']))
@@ -45,5 +47,5 @@ def redirect_to_first_question(response, survey):
 
 # Send a welcome message to the user
 def welcome_user(survey, send_function):
-    welcome_text = 'Welcome to MoveUp\'s SMS signup tool! To continue signing up, head to their website (...) or respond MOVEUP to this message to continue here.'
+    welcome_text = 'Welcome to Move Up! To sign up and get paired with a mentor, you can either continue here or head to our online form (https://bit.ly/moveup-signup). To continue here, please respond MOVEUP.'
     send_function(welcome_text)

--- a/backend/app/parsers.py
+++ b/backend/app/parsers.py
@@ -14,5 +14,6 @@ def questions_from_json(survey_json_string):
     for question_dict in questions_dicts:
         body = question_dict['body']
         kind = question_dict['type']
-        questions.append(Question(content=body, kind=kind))
+        values = question_dict['values']
+        questions.append(Question(content=body, kind=kind, enum_values=values))
     return questions

--- a/backend/signup_form.json
+++ b/backend/signup_form.json
@@ -1,17 +1,70 @@
 {
     "questions": [
       {
-        "body": "What is your name?",
-	"type": "text"
+        "body": "What's your first name?",
+	"type": "text",
+        "values": []	
       },
       {
-        "body": "What's your email address?",
-	"type": "email"
+        "body": "What's your last name?",
+	"type": "text",
+        "values": []
       },
       {
-        "body": "Rate your day so far. 1=good, 2=bad.",
-	"type": "enum"
+        "body": "Enter your email address.",
+	"type": "email",
+        "values": [] 
+      },
+      {
+        "body": "Enter a safe phone number to reach you.",
+	"type": "text",
+        "values": [] 
+      },
+      {
+        "body": "What state do you live in?",
+	"type": "text",
+        "values": [] 
+      },
+      {
+        "body": "What gender are you?\n1-Female\n2-Male\n3-Non-binary\n4-Prefer not to say",
+	"type": "enum",
+	"values": [ "Female", "Male", "Non-binary", "Prefer not to say" ]
+      }, 
+      {
+        "body": "What is your race/ethnicity?\n1-Asian/South Asian\n2-Black or African American\n3-Hispanic or Latino\n4-Native Hawaiian or Other Pacific Islander\n5-Caucasian/White\n6-American Indian or Alaska Native\n7-Other\n8-Prefer not to say",
+	"type": "enum",
+	"values": [ "Asian/South Asian", "Black or African American", "Hispanic or Latino", "Native Hawaiian or Other Pacific Islander", "Caucasian/White", "American Indian or Alaska Native", "Other", "Prefer not to say" ]
+      },
+      {
+        "body": "What's your age?\n1-Under 18\n2-18-24\n3-25-39\n4-40-54\n5-55-64\n6-65+\n7-Prefer not to say",
+	"type": "enum",
+	"values": [ "Under 18", "18-24", "25-39", "40-54", "55-64", "65+", "Prefer not to say" ]
+      },
+      {
+        "body": "What is your family's yearly income?\n1-Less than $20,000\n2-$20,000 to $34,999\n3-$35,000 to $49,999\n4-$50,000 to $99,999\n5-$100,000 to $149,999\n6-Over $150,000\n7-Prefer not to say",
+	"type": "enum",
+	"values": [ "Less than $20,000", "$20,000 to $34,999", "$35,000 to $49,999", "$50,000 to $99,999", "$100,000 to $149,999", "Over $150,000", "Prefer not to say" ]
+      },
+      {
+        "body": "What is your highest level of education and what did you study? (Can also state no degree, Move Up works with clients of all backgrounds!)\n1-Grammar School\n2-High School or equivalent\n3-Vocational/Technical School (2 year)\n4-Some College\n5-College Graduate (4 year)\n6-Master's Degree (MS)\n7-Doctoral Degree (PhD)\n8-Professional Degree (MD, JD, etc.)",
+	"type": "enum",
+	"values": [ "Grammar School", "High School or equivalent", "Vocational/Technical School (2 year)", "Some College", "College Graduate (4 year)", "Master's Degree (MS)", "Doctoral Degree (PhD)", "Professional Degree (MD, JD, etc.)" ]
+      }, 
+      {
+        "body": "How did you hear about Move Up?\n1-Facebook Group\n2-Move Up website\n3-Other Nonprofit\n4-Other",
+	"type": "enum",
+	"values": [ "Facebook Group", "Move Up website", "Other Nonprofit", "Other" ]
+      },
+      {
+        "body": "What days of the week and times (morning/evening) are best to call you?",
+	"type": "text",
+        "values": [] 
+      },
+      {
+        "body": "Please review the Move Up Release and Waiver of Liability. By printing your initials, you agree to the terms and conditions of Move Up's Release. https://bit.ly/1w7QueJ",
+	"type": "text",
+        "values": [] 
       }
-    ],
+     ],
     "title": "Sample form"
 }

--- a/backend/signup_form.json
+++ b/backend/signup_form.json
@@ -5,13 +5,13 @@
 	"type": "text"
       },
       {
-        "body": "Do you like this form?",
-	"type": "boolean"
+        "body": "What's your email address?",
+	"type": "email"
       },
       {
-        "body": "Rate your day so far.",
-	"type": "numeric"
+        "body": "Rate your day so far. 1=good, 2=bad.",
+	"type": "enum"
       }
     ],
-    "title": "Flask"
+    "title": "Sample form"
 }


### PR DESCRIPTION
# Summary

Classify questions as TEXT, EMAIL or ENUM and pattern match accordingly.
  * TEXT -- anything goes
  * EMAIL -- basic regex matching for xxx@xxx.xxx
  * ENUM -- is it an integer within the bounds of possible values?
<br>

There are separate response type classes for each of these types which handle answer validation, instructions as well as mapping the enum to the actual value for the ENUM type. Note that to do this mapping, each question in the JSON signup form has three fields: body (question), kind (TEXT, etc.) and values (array of possible values).
* Note: this could be handled better for ENUM. Since it requires information from the question, it needs to be called a little differently (see answer_views).
<br>

If a user enters an invalid message, they are told the input is invalid and prompted again with the question and instructions.

Better welcome message for users that includes a link to Move Up's online signup form (I used bit.ly so it's less annoying).

Filled in the survey with most of the real questions. Only missing available times because I'm not sure how to format it best. It also still asks for a safe phone number but this should be changed to either take the cell phone's number by default or give users the option.

## Test Plan

I ran the server and went through most of the survey (all question types) and clicked on any links to make sure they direct to the right place. I tested invalid inputs on EMAIL and both type-invalid and index-invalid errors for ENUM.

## Related Issues

#10 
#15 
#17 
