### PR TITLE
xinruili/fetch questions

### DIFF
--- a/backend/app/main/__init__.py
+++ b/backend/app/main/__init__.py
@@ -1,10 +1,36 @@
+import os
+import requests
+import json
 from flask import Blueprint
 from .parsers import survey_from_json
 
 main = Blueprint('main', __name__) 
 
-with open('signup_form.json') as survey_file:
-     signup_survey = survey_from_json(survey_file.read())
+questions = requests.get( "https://api.airtable.com/v0/appZa3BCfY1eRJCzU/Table%201",
+            headers={"Authorization": str(os.environ.get("AIRTABLE_XIN_TEST_KEY"))})
+
+if (questions.status_code == 200): 
+     questions_json = questions.json()
+     new_json_form = {
+     "questions": [
+          {
+          "text": questions_json["records"][0]["fields"]["Name question"],
+          "kind": "text",
+          "airtable_id": "Name"
+          },
+          {
+          "text": questions_json["records"][0]["fields"]["Email question"],
+          "kind": "email",
+          "airtable_id": "Email"
+          }
+     ],
+     "title": "sign-up form"
+     }
+     signup_survey = survey_from_json(json.dumps(new_json_form))
+
+else:
+     with open('signup_form.json') as survey_file:
+          signup_survey = survey_from_json(survey_file.read())
 
 from . import views, question_views, answer_views, survey_views
 

--- a/backend/app/main/__init__.py
+++ b/backend/app/main/__init__.py
@@ -6,6 +6,7 @@ from .parsers import survey_from_json
 
 main = Blueprint('main', __name__) 
 
+'''
 questions = requests.get( "https://api.airtable.com/v0/appZa3BCfY1eRJCzU/Table%201",
             headers={"Authorization": str(os.environ.get("AIRTABLE_XIN_TEST_KEY"))})
 
@@ -31,7 +32,7 @@ if (questions.status_code == 200):
 else:
      with open('signup_form.json') as survey_file:
           signup_survey = survey_from_json(survey_file.read())
-
+'''
 from . import views, question_views, answer_views, survey_views
 
 

--- a/backend/app/main/__init__.py
+++ b/backend/app/main/__init__.py
@@ -6,33 +6,6 @@ from .parsers import survey_from_json
 
 main = Blueprint('main', __name__) 
 
-'''
-questions = requests.get( "https://api.airtable.com/v0/appZa3BCfY1eRJCzU/Table%201",
-            headers={"Authorization": str(os.environ.get("AIRTABLE_XIN_TEST_KEY"))})
-
-if (questions.status_code == 200): 
-     questions_json = questions.json()
-     new_json_form = {
-     "questions": [
-          {
-          "text": questions_json["records"][0]["fields"]["Name question"],
-          "kind": "text",
-          "airtable_id": "Name"
-          },
-          {
-          "text": questions_json["records"][0]["fields"]["Email question"],
-          "kind": "email",
-          "airtable_id": "Email"
-          }
-     ],
-     "title": "sign-up form"
-     }
-     signup_survey = survey_from_json(json.dumps(new_json_form))
-
-else:
-     with open('signup_form.json') as survey_file:
-          signup_survey = survey_from_json(survey_file.read())
-'''
 from . import views, question_views, answer_views, survey_views
 
 

--- a/backend/app/main/answer_views.py
+++ b/backend/app/main/answer_views.py
@@ -2,14 +2,14 @@ from flask import url_for, session, request, jsonify
 from twilio.twiml.messaging_response import MessagingResponse
 import os
 import requests
-from . import main, signup_survey
+import jsonpickle
+from . import main
 from .response_types import TYPE_OBJECTS
-
 
 @main.route('/answer/<question_id>/<record_id>', methods=['POST','PATCH'])
 def answer(question_id, record_id):
 
-    question = signup_survey.get(question_id)
+    question = jsonpickle.decode(session["signup_survey"]).get(question_id)
 
     # Verify the response matches the expected type
     # If not, prompt user
@@ -22,7 +22,7 @@ def answer(question_id, record_id):
     else:
         update_airtable_record(record_id, question.airtable_id, request.values['Body'])
 
-    next_question = signup_survey.next(question_id)
+    next_question = jsonpickle.decode(session["signup_survey"]).next(question_id)
     if next_question:
         return redirect_twiml(next_question.id)
     else:

--- a/backend/app/main/answer_views.py
+++ b/backend/app/main/answer_views.py
@@ -13,7 +13,9 @@ def answer(question_id, record_id):
 
     # Verify the response matches the expected type
     # If not, prompt user
-    if not is_allowed_answer(request.values['Body'], question.kind):
+
+    # MINOR PROBLEM: Question kind is stored in a list for some reason
+    if not is_allowed_answer(request.values['Body'], question.kind[0]):
         return redirect_invalid_twiml(question.id)
 
     # Check the record id to see if the client's information exists in the Airtable

--- a/backend/app/main/answer_views.py
+++ b/backend/app/main/answer_views.py
@@ -15,8 +15,7 @@ def answer(question_id, record_id):
     # Verify the response matches the expected type
     # If not, prompt user
 
-    # MINOR PROBLEM: Question kind is stored in a list for some reason
-    if not is_allowed_answer(request.values['Body'], question.kind[0]):
+    if not is_allowed_answer(request.values['Body'], question.kind):
         return redirect_invalid_twiml(question.id)
     # Check the record id to see if the client's information exists in the Airtable
     if record_id == "NONE":

--- a/backend/app/main/models.py
+++ b/backend/app/main/models.py
@@ -29,6 +29,7 @@ class Survey():
     	if int(prev_id) < len(self.questions) - 1:
         	return self.questions[int(prev_id) + 1]
 
+# Encode Survey class to be JSON serializable
 class SurveyEncoder(JSONEncoder):
         def default(self, o):
             return o.__dict__

--- a/backend/app/main/models.py
+++ b/backend/app/main/models.py
@@ -1,3 +1,5 @@
+from json import JSONEncoder
+
 class Question():
     TEXT = 'text'
     EMAIL = 'email'
@@ -26,3 +28,7 @@ class Survey():
     def next(self, prev_id):
     	if int(prev_id) < len(self.questions) - 1:
         	return self.questions[int(prev_id) + 1]
+
+class SurveyEncoder(JSONEncoder):
+        def default(self, o):
+            return o.__dict__

--- a/backend/app/main/question_views.py
+++ b/backend/app/main/question_views.py
@@ -1,11 +1,12 @@
 from flask import session
 from twilio.twiml.messaging_response import MessagingResponse
-from . import main, signup_survey
+import jsonpickle
+from . import main
 
 # Get the next question
 @main.route('/question/<question_id>', methods=['GET'])
 def question(question_id):
-    question = signup_survey.get(question_id)
+    question = jsonpickle.decode(session["signup_survey"]).get(question_id)
     session['question_id'] = question.id
     return sms_twiml(question.text)
 

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -11,8 +11,8 @@ from . import main
 @main.route('/message', methods=['GET'])
 def sms_signup():
     response = MessagingResponse()    
-    questions = requests.get( "https://api.airtable.com/v0/appZa3BCfY1eRJCzU/Table%201",
-            headers={"Authorization": str(os.environ.get("AIRTABLE_XIN_TEST_KEY"))})
+    questions = requests.get( "https://api.airtable.com/v0/appw4RRMDig1g2PFI/SMS%20Questions/recRT4MAzeLUnLB7l",
+            headers={"Authorization": str(os.environ.get("API_KEY"))})
 
     if (questions.status_code == 200): 
         questions_json = questions.json()
@@ -21,14 +21,14 @@ def sms_signup():
         ],
         "title": "sign-up form"
         }
-        for (key, value) in questions_json["records"][0]["fields"].items():
+        for (key, value) in questions_json["fields"].items():
             kind = "email" if key == "Email" else "text",
             new_question = {
             "text": value,
             "kind": kind,
             "airtable_id": key
             }
-            new_json_form["questions"].insert(0, new_question)
+            new_json_form["questions"].append(new_question)
         # End of question retrieval
 
         # Encoding survey so it is JSON serializable in order to be stored in the session    

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -24,7 +24,7 @@ def sms_signup():
         "title": "sign-up form"
         }
         for (key, value) in questions_json["fields"].items():
-            kind = "email" if key == "Email" else "text",
+            kind = "email" if key == "Email" else "text"
             new_question = {
             "text": value,
             "kind": kind,

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -18,25 +18,27 @@ def sms_signup():
         questions_json = questions.json()
         new_json_form = {
         "questions": [
-            {
-            "text": questions_json["records"][0]["fields"]["Name question"],
-            "kind": "text",
-            "airtable_id": "Name"
-            },
-            {
-            "text": questions_json["records"][0]["fields"]["Email question"],
-            "kind": "email",
-            "airtable_id": "Email"
-            }
         ],
         "title": "sign-up form"
         }
+        for (key, value) in questions_json["records"][0]["fields"].items():
+            kind = "email" if key == "Email" else "text",
+            new_question = {
+            "text": value,
+            "kind": kind,
+            "airtable_id": key
+            }
+            new_json_form["questions"].insert(0, new_question)
+        # End of question retrieval
+
+        # Encoding survey so it is JSON serializable in order to be stored in the session    
         session["signup_survey"] = jsonpickle.encode(survey_from_json(json.dumps(new_json_form)))
 
     else:
         with open('signup_form.json') as survey_file:
             session["signup_survey"] = jsonpickle.encode(survey_from_json(survey_file.read()))
 
+    # Retrieving the survey from the session requires it to be decoded
     if survey_error(jsonpickle.decode(session["signup_survey"]), response.message):
         return str(response)
     

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -35,6 +35,7 @@ def sms_signup():
         session["signup_survey"] = jsonpickle.encode(survey_from_json(json.dumps(new_json_form)))
 
     else:
+        # If the request fails, get the default name and email questions.
         with open('signup_form.json') as survey_file:
             session["signup_survey"] = jsonpickle.encode(survey_from_json(survey_file.read()))
 

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -94,7 +94,7 @@ def welcome_user(send_function, is_prev_response=False):
 # Check if record already exists
 def retrieve_prev_record(phone_number):
     prev_response = requests.get( 
-            config[os.getenv("FLASK_CONFIG")].DATABASE_URL + "?filterByFormula={Phone_Number}='" + phone_number + "'",
+            config[os.getenv("FLASK_CONFIG")].DATABASE_URL + "?filterByFormula={Phone_Number}='" + "+" + phone_number + "'",
             headers={"Authorization": str(os.environ.get("API_KEY"))})
     # Default value for response id 
     response_id = "NONE"

--- a/backend/app/main/survey_views.py
+++ b/backend/app/main/survey_views.py
@@ -13,9 +13,9 @@ import app
 @main.route('/message', methods=['GET'])
 def sms_signup():
     response = MessagingResponse()    
-    questions = requests.get( "https://api.airtable.com/v0/appw4RRMDig1g2PFI/SMS%20Questions/recRT4MAzeLUnLB7l",
+    questions = requests.get(
+            config[os.getenv("FLASK_CONFIG")].QUESTIONS_URL,
             headers={"Authorization": str(os.environ.get("API_KEY"))})
-
     if (questions.status_code == 200): 
         questions_json = questions.json()
         new_json_form = {

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,6 +10,11 @@ class Config:
             return str(os.environ.get("PROD_URL"))
         else: return str(os.environ.get("DEV_URL"))
 
+    @property
+    def QUESTIONS_URL(self):
+        if os.getenv("FLASK_CONFIG")=='production':
+            return str(os.environ.get("PROD_QUESTIONS_URL"))
+        else: return str(os.environ.get("DEV_QUESTIONS_URL"))
     @staticmethod
     def init_app(app):
         pass

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ idna==2.8
 isort==4.3.21
 itsdangerous==1.1.0
 Jinja2==2.10.1
+jsonpickle==1.4.1    
 lazy-object-proxy==1.4.1
 Mako==1.0.13
 MarkupSafe==1.1.1


### PR DESCRIPTION
# Summary
- Fetching questions from separate table and storing them inside the session.
- Able to add new questions to the table if a corresponding field is present in the SMS responses table.
- Added the QUESTION_URL property to config.py to have a production question table and a development table.


## Test Plan
I tested adding new questions and changing current questions and made sure that it added the response correctly to the response table. I tested the production and the dev environment.

## Related Issues
#40 
